### PR TITLE
Add CoMaps

### DIFF
--- a/src/data/services.json
+++ b/src/data/services.json
@@ -1503,17 +1503,19 @@
         "name": "Organic Maps",
         "osmwiki": "Organic_Maps",
         "github": "organicmaps",
-        "url": "om://map",
-        "query": {
-            "v": "1",
-            "ll": "{{lat}},{{lon}}"
-        },
+        "url": "https://organicmaps.app/",
+        "cat": "mobile"
+    },
+    "coMaps": {
+        "name": "CoMaps",
+        "osmwiki": "CoMaps",
+        "url": "https://www.comaps.app/",
         "cat": "mobile"
     },
     "magicEarth": {
         "name": "Magic Earth",
         "osmwiki": "Magic_Earth",
-        "url": "magicearth://",
+        "url": "https://www.magicearth.com/",
         "slug": "?show_on_map&lat={{lat}}&lon={{lon}}",
         "cat": "mobile"
     },

--- a/src/data/services.json
+++ b/src/data/services.json
@@ -1516,7 +1516,6 @@
         "name": "Magic Earth",
         "osmwiki": "Magic_Earth",
         "url": "https://www.magicearth.com/",
-        "slug": "?show_on_map&lat={{lat}}&lon={{lon}}",
         "cat": "mobile"
     },
     "openhistoricalmap": {


### PR DESCRIPTION
### Changes

- Adds [CoMaps](https://www.comaps.app/)
   - Does not add source code as there doesn't seem to be a codeburg key?
- Updates URLs for Organic Maps and Magic Earth to no longer use protocol URLs
   - These only work if the user has the app installed which seems counter-intuitive to a directory of apps?